### PR TITLE
Remove duplicated work method.

### DIFF
--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -479,6 +479,9 @@ class BodhiConfig(dict):
         'pkgdb_url': {
             'value': 'https://admin.fedoraproject.org/pkgdb',
             'validator': unicode},
+        'pungi_config_path': {
+            'value': '/etc/bodhi/pungi/fedora-modular.conf',
+            'validator': unicode},
         'query_wiki_test_cases': {
             'value': False,
             'validator': _validate_bool},

--- a/bodhi/server/config.py
+++ b/bodhi/server/config.py
@@ -479,7 +479,7 @@ class BodhiConfig(dict):
         'pkgdb_url': {
             'value': 'https://admin.fedoraproject.org/pkgdb',
             'validator': unicode},
-        'pungi_config_path': {
+        'pungi_modular_config_path': {
             'value': '/etc/bodhi/pungi/fedora-modular.conf',
             'validator': unicode},
         'query_wiki_test_cases': {

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -1080,14 +1080,6 @@ class PungiMasherThread(MasherThread):
     def _get_compose_dir(self, mash_path, variant_id="Server"):
         return os.path.join(mash_path, "compose", variant_id)
 
-    def _get_pungi_conf_path(self, config_name="fedora-modular-example.conf"):
-        if config.get("pungi_config_path"):
-            return os.path.join(config.get("pungi_config_path"), config_name)
-        else:
-            return os.path.join(
-                os.path.dirname(os.getcwd()), "bodhi", "devel", "pungi", config_name
-            )
-
     def sanity_check_repo(self):
         """Sanity check our repo.
 
@@ -1123,8 +1115,7 @@ class PungiMasherThread(MasherThread):
             self.log.info('Skipping completed repo: %s', self.path)
             return
 
-        # TODO get from bodhi config
-        self.pungi_conf_path = self._get_pungi_conf_path()
+        self.pungi_conf_path = config.get("pungi_config_path")
         self.pungi_conf = PungiConfig(path=self.pungi_conf_path, logger=self.log)
         # TODO variants config needs to reflect the whole build not only updated modules
         # also the variants id needs to be provided from somewhere.

--- a/bodhi/server/consumers/masher.py
+++ b/bodhi/server/consumers/masher.py
@@ -1115,7 +1115,7 @@ class PungiMasherThread(MasherThread):
             self.log.info('Skipping completed repo: %s', self.path)
             return
 
-        self.pungi_conf_path = config.get("pungi_config_path")
+        self.pungi_conf_path = config.get("pungi_modular_config_path")
         self.pungi_conf = PungiConfig(path=self.pungi_conf_path, logger=self.log)
         # TODO variants config needs to reflect the whole build not only updated modules
         # also the variants id needs to be provided from somewhere.

--- a/bodhi/tests/server/consumers/test_masher.py
+++ b/bodhi/tests/server/consumers/test_masher.py
@@ -1483,6 +1483,7 @@ class TestMasherThread_update_comps(unittest.TestCase):
     def setUp(self):
         self.masher_thread = MasherThread(u'F17', u'stable', [u'bodhi-2.0-1.fc17'],
                                           u'bowlofeggs', mock.Mock(), mock.Mock(), mock.Mock())
+        self.masher_thread.id = "whatever"  # not-modular
 
     @mock.patch('bodhi.server.consumers.masher.os.path.exists')
     @mock.patch('bodhi.server.consumers.masher.config', {'comps_dir': '/some/path',


### PR DESCRIPTION
The baseclass and this child class shared almost exactly the same `work()`
method.  This removes the child one and augments some methods of the parent so
that the same behavior is achieved.